### PR TITLE
Reorganized and styled HTML template

### DIFF
--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -1,9 +1,8 @@
 body {
-	background-color: #fff;
+	background-color: #ccc;
 	color: #000;
 	font-family: sans-serif;
 	line-height: 1.5;
-	max-width: 40em;
 	margin: 0 auto;
 }
 footer {
@@ -12,16 +11,13 @@ footer {
 	text-align: center;
 	opacity: 0.5;
 }
-main h1 { color: #469; }
 header h1 { background-color: #469; color: #fff; text-align: center; font-weight: normal; }
-.event {
-	display: flex;
-	align-items: top;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	flex-direction: row;
-}
-.event .eventtext { flex-basis: 60%; }
-.event .eventimage { flex-basis: 30%; flex-shrink: 1; }
-.event h1 { margin-bottom: 0; }
-.event address { font-style: unset; }
+
+main { display: flex; flex-flow: row wrap; }
+
+article.event { margin: 0.5rem; background-color: #fff; flex: 1 0 23%; min-width: 15em; }
+article.event:nth-last-child(2):nth-child(4n) { min-width: 33%; }
+article.event div.eventpic { background-size: cover;}
+article.event h1 { color: #000; padding: 8rem 0.5rem 0; background-image: linear-gradient(transparent, white); margin: 0;}
+article.event div.eventbody { padding-left: 0.5rem; padding-right: 0.5rem; }
+article.event address { font-style: unset; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -1,5 +1,5 @@
 body {
-	background-color: #ccc;
+	background-color: #eee;
 	color: #000;
 	font-family: sans-serif;
 	line-height: 1.5;
@@ -11,13 +11,44 @@ footer {
 	text-align: center;
 	opacity: 0.5;
 }
-header h1 { background-color: #469; color: #fff; text-align: center; font-weight: normal; }
+header h1 {
+	background: linear-gradient(#247, #469);
+	color: #fff;
+	text-align: center;
+	font-weight: normal;
+	margin: 0;
+	padding: 0.75em 0;
+	box-shadow: inset 0 -2px 5px rgba(0,0,0,0.2);
+	letter-spacing: 0.25ch;
+}
 
-main { display: flex; flex-flow: row wrap; }
+main { display: flex; flex-flow: row wrap; margin: 0.25rem; }
 
-article.event { margin: 0.5rem; background-color: #fff; flex: 1 0 23%; min-width: 15em; }
+article.event {
+	margin: 0.5rem;
+	background-color: #fff;
+	flex: 1 0 23%;
+	min-width: 15em;
+	box-shadow: 0 0 0 1px #ccc, 2px 2px 6px rgba(0,0,0,0.16);
+	border-radius: 0.5rem;
+}
 article.event:nth-last-child(2):nth-child(4n) { min-width: 33%; }
-article.event div.eventpic { background-size: cover;}
-article.event h1 { color: #000; padding: 8rem 0.5rem 0; background-image: linear-gradient(transparent, white); margin: 0;}
+article.event div.eventpic {
+	background-size: cover;
+	 border-top-left-radius: 0.5rem;
+	 border-top-right-radius: 0.5rem;
+	display: flex;
+	min-height: 15rem;
+	align-items: center;
+	text-align: center;
+	flex-direction: column;
+	justify-content: space-evenly;
+	color: #000;
+	text-shadow: 1px 1px 6px #fff;
+}
+article.event h1 {
+	padding: 0 0.5rem;
+	margin: 0;
+}
 article.event div.eventbody { padding-left: 0.5rem; padding-right: 0.5rem; }
 article.event address { font-style: unset; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -5,12 +5,6 @@ body {
 	line-height: 1.5;
 	margin: 0 auto;
 }
-footer {
-	font-size: 0.75em;
-	line-height: 2;
-	text-align: center;
-	opacity: 0.5;
-}
 header h1 {
 	background: linear-gradient(#247, #469);
 	color: #fff;

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -12,6 +12,16 @@ footer {
 	text-align: center;
 	opacity: 0.5;
 }
-h1 {
-	color: #446699;
+main h1 { color: #469; }
+header h1 { background-color: #469; color: #fff; text-align: center; font-weight: normal; }
+.event {
+	display: flex;
+	align-items: top;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	flex-direction: row;
 }
+.event .eventtext { flex-basis: 60%; }
+.event .eventimage { flex-basis: 30%; flex-shrink: 1; }
+.event h1 { margin-bottom: 0; }
+.event address { font-style: unset; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -1,0 +1,17 @@
+body {
+	background-color: #fff;
+	color: #000;
+	font-family: sans-serif;
+	line-height: 1.5;
+	max-width: 40em;
+	margin: 0 auto;
+}
+footer {
+	font-size: 0.75em;
+	line-height: 2;
+	text-align: center;
+	opacity: 0.5;
+}
+h1 {
+	color: #446699;
+}

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -1,7 +1,8 @@
 {% extends 'base.html' %}
+{% load staticfiles %}
 
 {% block fulltitle %}EA Boston Events{% endblock fulltitle %}
-
+{% block styling %}<link rel="stylesheet" href="{% static 'css/simplesheet.css' %}">{% endblock styling %}
 {% block content %}
   <h1>EA Boston Events</h1>
   {% if event_list %}

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -9,13 +9,13 @@
     <main>
       {% for event in event_list %}
         <article class="event">
-          <div class="eventpic" style="background-image: url('{{ event.picture.url }}')">
+          <div class="eventpic" style="background: linear-gradient(rgba(255,255,255,0.5),rgba(255,255,255,0.5)), url('{{ event.picture.url }}')">
             <h1>{{ event.name }}</h1>
-          </div>
-          <div class="eventbody">
             <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
           {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
             <address>{{ event.location }}</address>
+          </div>
+          <div class="eventbody">
             <p>{{ event.description }}</p>
           </div>
         </article>

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -9,14 +9,15 @@
     <main>
       {% for event in event_list %}
         <article class="event">
-          <div class="eventtext">
-          <h1>{{ event.name }}</h1>
-          <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
-          {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
-          <address>{{ event.location }}</address>
-          <p>{{ event.description }}</p>
+          <div class="eventpic" style="background-image: url('{{ event.picture.url }}')">
+            <h1>{{ event.name }}</h1>
           </div>
-          <img src="{{ event.picture.url }}" alt="" class="eventpic">
+          <div class="eventbody">
+            <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
+          {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
+            <address>{{ event.location }}</address>
+            <p>{{ event.description }}</p>
+          </div>
         </article>
       {% endfor %}
     </main>

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -4,18 +4,22 @@
 {% block fulltitle %}EA Boston Events{% endblock fulltitle %}
 {% block styling %}<link rel="stylesheet" href="{% static 'css/simplesheet.css' %}">{% endblock styling %}
 {% block content %}
-  <h1>EA Boston Events</h1>
+  <header><h1>EA Boston Events</h1></header>
   {% if event_list %}
-    <ul>
+    <main>
       {% for event in event_list %}
-        <li>
-          <h2>{{ event.title }}</h2>
-          <h3>{{ event.start_time }}{% if event.end_time %}–{{ event.end_time }}{% endif %}, {{ event.location }}</h3>
-          <img src="{{ event.picture.url }}" alt="{{ event.title }}">
+        <article class="event">
+          <div class="eventtext">
+          <h1>{{ event.name }}</h1>
+          <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
+          {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
+          <address>{{ event.location }}</address>
           <p>{{ event.description }}</p>
-        </li>
+          </div>
+          <img src="{{ event.picture.url }}" alt="" class="eventpic">
+        </article>
       {% endfor %}
-    </ul>
+    </main>
   {% else %}
     <p>There are no events scheduled right now.</p>
   {% endif %}

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -8,6 +8,5 @@
   </head>
   <body>
     {% block content %}{% endblock content %}
-    <footer><p>EA Boston | Copyright 2017 Taymon Beal, Daniel Ziegler | Powered by Django</p></footer>
   </body>
 </html>

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -7,7 +7,7 @@
     {% block styling %}{% endblock styling %}
   </head>
   <body>
-    <main>{% block content %}{% endblock content %}</main>
+    {% block content %}{% endblock content %}
     <footer><p>EA Boston | Copyright 2017 Taymon Beal, Daniel Ziegler | Powered by Django</p></footer>
   </body>
 </html>

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8">
     <title>{% block fulltitle %}{% block title %}{% endblock title %} – EA Boston{% endblock fulltitle %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% block styling %}{% endblock styling %}
   </head>
-  <body>{% block content %}{% endblock content %}</body>
+  <body>
+    <main>{% block content %}{% endblock content %}</main>
+    <footer><p>EA Boston | Copyright 2017 Taymon Beal, Daniel Ziegler | Powered by Django</p></footer>
+  </body>
 </html>


### PR DESCRIPTION
I modified the base HTML template to support use of a stylesheet. I then reorganized the events page to be more styleable, and wrote a stylesheet to go with it, using a mobile-friendly flexbox-based layout. I am sorry about the `background: linear-gradient(rgba(255,255,255,0.5),rgba(255,255,255,0.5))` bit, but other more sensible methods just didn't work, and about using `<address>` tags for event locations.