### PR TITLE
New responsive collapsible layout style

### DIFF
--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -21,7 +21,8 @@ summary .date { margin: 0; }
 	main { display: flex; flex-flow: row wrap; justify-content: space-evenly; }
 	body { line-height: 1.5; background-color: #ded; }
 	header h1 { font-size: 2em; padding: 0.5em 0; }
-	details { padding: 0.5em; margin: 0.5em; border: solid thin; min-width: 20rem; min-height: 8em; flex: 1 0 30%;}
+	details { padding: 0.5em; margin: 0.5em; border: solid thin; min-width: 20rem; max-width: 40rem; min-height: 8em; flex: 1 0 30%;}
+	details:not([open]) { height: 8em; }
 	details[open] { border-color: #060; }
 	summary h1 { font-size: 1.5em; line-height: 1.25; }
 	summary img { height: 8em; margin-right: 0.5em; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -1,9 +1,8 @@
 body {
-	background-color: #fff;
+	background-color: #ccc;
 	color: #000;
 	font-family: sans-serif;
 	line-height: 1.5;
-	max-width: 40em;
 	margin: 0 auto;
 }
 footer {
@@ -12,16 +11,13 @@ footer {
 	text-align: center;
 	opacity: 0.5;
 }
-main h1 { color: #469; }
 header h1 { background-color: #469; color: #fff; text-align: center; font-weight: normal; }
-.event {
-	display: flex;
-	align-items: top;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	flex-direction: row;
-}
-.event .eventtext { flex-basis: 60%; }
-.event .eventimage { flex-basis: 30%; flex-shrink: 1; }
-.event h1 { margin-bottom: 0; }
-.event address { font-style: unset; }
+
+main { display: flex; flex-flow: row wrap; }
+
+article.event { margin: 0.5rem; background-color: #fff; flex: 1 0 23%; min-width: 15em; }
+article.event:nth-last-child(2):nth-child(4n) { min-width: 33%; }
+article.event div.eventpic { background-size: cover;}
+article.event h1 { color: #000; padding: 8rem 0.5rem 0; background-image: linear-gradient(transparent, white); margin: 0;}
+article.event div.eventbody { padding-left: 0.5rem; padding-right: 0.5rem; }
+article.event address { font-style: unset; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -1,9 +1,8 @@
 body {
-	background-color: #eee;
+	background-color: #fff;
 	color: #000;
-	font-family: sans-serif;
-	line-height: 1.5;
-	margin: 0 auto;
+	font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
+	margin: 0;
 }
 header h1 {
 	background: linear-gradient(#247, #469);
@@ -11,38 +10,35 @@ header h1 {
 	text-align: center;
 	font-weight: normal;
 	margin: 0;
-	padding: 0.75em 0;
 	box-shadow: inset 0 -2px 5px rgba(0,0,0,0.2);
-	letter-spacing: 0.25ch;
 }
 
-main { display: flex; flex-flow: row wrap; margin: 0.25rem; }
+details { background-color: #fff; }
+summary { display: block; }
+summary h1 { margin: 0; }
+summary img { float: left; }
+summary .date { margin: 0; }
 
-article.event {
-	margin: 0.5rem;
-	background-color: #fff;
-	flex: 1 0 23%;
-	min-width: 15em;
-	box-shadow: 0 0 0 1px #ccc, 2px 2px 6px rgba(0,0,0,0.16);
-	border-radius: 0.5rem;
+/* Sizing on large devices */
+@media (min-width: 30.001rem) {
+	main { max-width: 40rem; margin: 0 auto; }
+	body { line-height: 1.5 }
+	header h1 { padding: 0.5em 0 }
+	details { background-color: #fff; padding: 0.5em; margin: 1em; border: solid thin; }
+	summary { line-height: 2em; }
+	summary h1 { font-size: 1.5em; }
+	summary img { height: 4em; margin-right: 0.5em; }
+	details p:last-child { margin-bottom: 0; }
 }
-article.event:nth-last-child(2):nth-child(4n) { min-width: 33%; }
-article.event div.eventpic {
-	background-size: cover;
-	 border-top-left-radius: 0.5rem;
-	 border-top-right-radius: 0.5rem;
-	display: flex;
-	min-height: 15rem;
-	align-items: center;
-	text-align: center;
-	flex-direction: column;
-	justify-content: space-evenly;
-	color: #000;
-	text-shadow: 1px 1px 6px #fff;
+
+/* Sizing on small devices */
+@media (max-width: 30rem) {
+	body { font-size: 0.8em; line-height: 1.25; }
+	header h1 { padding: 0.1em 0; font-size: 2em; margin-bottom: 0.2em; }
+	details { padding: 0.2em; border-bottom: solid thin; }
+	article:first-child details { border-top: solid thin; }
+	summary h1 { font-size: 1.25em; line-height: 1; }
+	summary img { height: 2.5em; margin-right: 0.1em; }
+	p { margin: 0.5em 0; }
+	details p:last-child { margin-bottom: 0; }
 }
-article.event h1 {
-	padding: 0 0.5rem;
-	margin: 0;
-}
-article.event div.eventbody { padding-left: 0.5rem; padding-right: 0.5rem; }
-article.event address { font-style: unset; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -1,5 +1,5 @@
 body {
-	background-color: #ccc;
+	background-color: #eee;
 	color: #000;
 	font-family: sans-serif;
 	line-height: 1.5;
@@ -11,13 +11,44 @@ footer {
 	text-align: center;
 	opacity: 0.5;
 }
-header h1 { background-color: #469; color: #fff; text-align: center; font-weight: normal; }
+header h1 {
+	background: linear-gradient(#247, #469);
+	color: #fff;
+	text-align: center;
+	font-weight: normal;
+	margin: 0;
+	padding: 0.75em 0;
+	box-shadow: inset 0 -2px 5px rgba(0,0,0,0.2);
+	letter-spacing: 0.25ch;
+}
 
-main { display: flex; flex-flow: row wrap; }
+main { display: flex; flex-flow: row wrap; margin: 0.25rem; }
 
-article.event { margin: 0.5rem; background-color: #fff; flex: 1 0 23%; min-width: 15em; }
+article.event {
+	margin: 0.5rem;
+	background-color: #fff;
+	flex: 1 0 23%;
+	min-width: 15em;
+	box-shadow: 0 0 0 1px #ccc, 2px 2px 6px rgba(0,0,0,0.16);
+	border-radius: 0.5rem;
+}
 article.event:nth-last-child(2):nth-child(4n) { min-width: 33%; }
-article.event div.eventpic { background-size: cover;}
-article.event h1 { color: #000; padding: 8rem 0.5rem 0; background-image: linear-gradient(transparent, white); margin: 0;}
+article.event div.eventpic {
+	background-size: cover;
+	 border-top-left-radius: 0.5rem;
+	 border-top-right-radius: 0.5rem;
+	display: flex;
+	min-height: 15rem;
+	align-items: center;
+	text-align: center;
+	flex-direction: column;
+	justify-content: space-evenly;
+	color: #000;
+	text-shadow: 1px 1px 6px #fff;
+}
+article.event h1 {
+	padding: 0 0.5rem;
+	margin: 0;
+}
 article.event div.eventbody { padding-left: 0.5rem; padding-right: 0.5rem; }
 article.event address { font-style: unset; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -5,12 +5,6 @@ body {
 	line-height: 1.5;
 	margin: 0 auto;
 }
-footer {
-	font-size: 0.75em;
-	line-height: 2;
-	text-align: center;
-	opacity: 0.5;
-}
 header h1 {
 	background: linear-gradient(#247, #469);
 	color: #fff;

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -12,6 +12,16 @@ footer {
 	text-align: center;
 	opacity: 0.5;
 }
-h1 {
-	color: #446699;
+main h1 { color: #469; }
+header h1 { background-color: #469; color: #fff; text-align: center; font-weight: normal; }
+.event {
+	display: flex;
+	align-items: top;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	flex-direction: row;
 }
+.event .eventtext { flex-basis: 60%; }
+.event .eventimage { flex-basis: 30%; flex-shrink: 1; }
+.event h1 { margin-bottom: 0; }
+.event address { font-style: unset; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -22,8 +22,8 @@ summary .date { margin: 0; }
 	body { line-height: 1.5; background-color: #ded; }
 	header h1 { font-size: 2em; padding: 0.5em 0; }
 	details { padding: 0.5em; margin: 0.5em; border: solid thin; flex: 1 0 20%;}
-	details:not([open]) { height: 8em; min-width: 20rem; max-width: 40rem; }
-	details[open] { min-width: calc(100% - 2em); min-height: 8em; }
+	details:not([open]) { height: 8em; min-width: 20rem; max-width: 40rem; order: 2; }
+	details[open] { min-width: calc(100% - 2em); min-height: 8em; order: 1; }
 	summary h1 { font-size: 1.5em; line-height: 1.25; }
 	summary img { height: 8em; margin-right: 0.5em; }
 	details p:last-child { margin-bottom: 0; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -18,12 +18,12 @@ summary .date { margin: 0; }
 
 /* Behavior on large devices */
 @media (min-width: 30.001rem) {
-	main { display: flex; flex-flow: row wrap; justify-content: space-evenly; }
+	main { display: flex; flex-flow: row wrap; justify-content: space-evenly; max-width: 90em; margin: 0 auto; }
 	body { line-height: 1.5; background-color: #ded; }
 	header h1 { font-size: 2em; padding: 0.5em 0; }
-	details { padding: 0.5em; margin: 0.5em; border: solid thin; min-width: 20rem; max-width: 40rem; min-height: 8em; flex: 1 0 30%;}
-	details:not([open]) { height: 8em; }
-	details[open] { border-color: #060; }
+	details { padding: 0.5em; margin: 0.5em; border: solid thin; flex: 1 0 20%;}
+	details:not([open]) { height: 8em; min-width: 20rem; max-width: 40rem; }
+	details[open] { min-width: calc(100% - 2em); min-height: 8em; }
 	summary h1 { font-size: 1.5em; line-height: 1.25; }
 	summary img { height: 8em; margin-right: 0.5em; }
 	details p:last-child { margin-bottom: 0; }

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -1,0 +1,17 @@
+body {
+	background-color: #fff;
+	color: #000;
+	font-family: sans-serif;
+	line-height: 1.5;
+	max-width: 40em;
+	margin: 0 auto;
+}
+footer {
+	font-size: 0.75em;
+	line-height: 2;
+	text-align: center;
+	opacity: 0.5;
+}
+h1 {
+	color: #446699;
+}

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -1,42 +1,39 @@
 body {
-	background-color: #fff;
-	color: #000;
 	font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
 	margin: 0;
 }
 header h1 {
-	background: linear-gradient(#247, #469);
+	background: linear-gradient(#054410, #364 90%, #306040);
 	color: #fff;
 	text-align: center;
 	font-weight: normal;
 	margin: 0;
-	box-shadow: inset 0 -2px 5px rgba(0,0,0,0.2);
 }
 
-details { background-color: #fff; }
+details { background-color: #fff; color: #000; }
 summary { display: block; }
 summary h1 { margin: 0; }
 summary img { float: left; }
 summary .date { margin: 0; }
 
-/* Sizing on large devices */
+/* Behavior on large devices */
 @media (min-width: 30.001rem) {
-	main { max-width: 40rem; margin: 0 auto; }
-	body { line-height: 1.5 }
-	header h1 { padding: 0.5em 0 }
-	details { background-color: #fff; padding: 0.5em; margin: 1em; border: solid thin; }
-	summary { line-height: 2em; }
-	summary h1 { font-size: 1.5em; }
-	summary img { height: 4em; margin-right: 0.5em; }
+	main { display: flex; flex-flow: row wrap; justify-content: space-evenly; }
+	body { line-height: 1.5; background-color: #ded; }
+	header h1 { font-size: 2em; padding: 0.5em 0; }
+	details { padding: 0.5em; margin: 0.5em; border: solid thin; min-width: 20rem; min-height: 8em; flex: 1 0 30%;}
+	details[open] { border-color: #060; }
+	summary h1 { font-size: 1.5em; line-height: 1.25; }
+	summary img { height: 8em; margin-right: 0.5em; }
 	details p:last-child { margin-bottom: 0; }
 }
 
-/* Sizing on small devices */
+/* Behavior on small devices */
 @media (max-width: 30rem) {
-	body { font-size: 0.8em; line-height: 1.25; }
+	body { font-size: 0.8em; line-height: 1.25; background-color: #fff; }
 	header h1 { padding: 0.1em 0; font-size: 2em; margin-bottom: 0.2em; }
 	details { padding: 0.2em; border-bottom: solid thin; }
-	article:first-child details { border-top: solid thin; }
+	details:first-child { border-top: solid thin; }
 	summary h1 { font-size: 1.25em; line-height: 1; }
 	summary img { height: 2.5em; margin-right: 0.1em; }
 	p { margin: 0.5em 0; }

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -9,15 +9,15 @@
     <main>
       {% for event in event_list %}
         <article class="event">
-          <div class="eventpic" style="background: linear-gradient(rgba(255,255,255,0.5),rgba(255,255,255,0.5)), url('{{ event.picture.url }}')">
-            <h1>{{ event.name }}</h1>
-            <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
-          {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
-            <address>{{ event.location }}</address>
-          </div>
-          <div class="eventbody">
+          <details>
+            <summary>
+              <img src="{{ event.picture.url }}" alt=""/>
+              <h1>{{ event.name }}</h1>
+              <p class="date"><time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>{% if event.end_time %} -- <time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}</p>
+            </summary>
+            <p>{{ event.location }}</p>
             <p>{{ event.description }}</p>
-          </div>
+          </details>
         </article>
       {% endfor %}
     </main>

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -8,7 +8,6 @@
   {% if event_list %}
     <main>
       {% for event in event_list %}
-        <article class="event">
           <details>
             <summary>
               <img src="{{ event.picture.url }}" alt=""/>
@@ -18,7 +17,6 @@
             <p>{{ event.location }}</p>
             <p>{{ event.description }}</p>
           </details>
-        </article>
       {% endfor %}
     </main>
   {% else %}

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -1,7 +1,8 @@
 {% extends 'base.html' %}
+{% load staticfiles %}
 
 {% block fulltitle %}EA Boston Events{% endblock fulltitle %}
-
+{% block styling %}<link rel="stylesheet" href="{% static 'css/simplesheet.css' %}">{% endblock styling %}
 {% block content %}
   <h1>EA Boston Events</h1>
   {% if event_list %}

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -9,13 +9,13 @@
     <main>
       {% for event in event_list %}
         <article class="event">
-          <div class="eventpic" style="background-image: url('{{ event.picture.url }}')">
+          <div class="eventpic" style="background: linear-gradient(rgba(255,255,255,0.5),rgba(255,255,255,0.5)), url('{{ event.picture.url }}')">
             <h1>{{ event.name }}</h1>
-          </div>
-          <div class="eventbody">
             <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
           {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
             <address>{{ event.location }}</address>
+          </div>
+          <div class="eventbody">
             <p>{{ event.description }}</p>
           </div>
         </article>

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -9,14 +9,15 @@
     <main>
       {% for event in event_list %}
         <article class="event">
-          <div class="eventtext">
-          <h1>{{ event.name }}</h1>
-          <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
-          {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
-          <address>{{ event.location }}</address>
-          <p>{{ event.description }}</p>
+          <div class="eventpic" style="background-image: url('{{ event.picture.url }}')">
+            <h1>{{ event.name }}</h1>
           </div>
-          <img src="{{ event.picture.url }}" alt="" class="eventpic">
+          <div class="eventbody">
+            <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
+          {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
+            <address>{{ event.location }}</address>
+            <p>{{ event.description }}</p>
+          </div>
         </article>
       {% endfor %}
     </main>

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -4,18 +4,22 @@
 {% block fulltitle %}EA Boston Events{% endblock fulltitle %}
 {% block styling %}<link rel="stylesheet" href="{% static 'css/simplesheet.css' %}">{% endblock styling %}
 {% block content %}
-  <h1>EA Boston Events</h1>
+  <header><h1>EA Boston Events</h1></header>
   {% if event_list %}
-    <ul>
+    <main>
       {% for event in event_list %}
-        <li>
-          <h2>{{ event.title }}</h2>
-          <h3>{{ event.start_time }}{% if event.end_time %}–{{ event.end_time }}{% endif %}, {{ event.location }}</h3>
-          <img src="{{ event.picture.url }}" alt="{{ event.title }}">
+        <article class="event">
+          <div class="eventtext">
+          <h1>{{ event.name }}</h1>
+          <time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>
+          {% if event.end_time %}<time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}
+          <address>{{ event.location }}</address>
           <p>{{ event.description }}</p>
-        </li>
+          </div>
+          <img src="{{ event.picture.url }}" alt="" class="eventpic">
+        </article>
       {% endfor %}
-    </ul>
+    </main>
   {% else %}
     <p>There are no events scheduled right now.</p>
   {% endif %}

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -8,6 +8,5 @@
   </head>
   <body>
     {% block content %}{% endblock content %}
-    <footer><p>EA Boston | Copyright 2017 Taymon Beal, Daniel Ziegler | Powered by Django</p></footer>
   </body>
 </html>

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -7,7 +7,7 @@
     {% block styling %}{% endblock styling %}
   </head>
   <body>
-    <main>{% block content %}{% endblock content %}</main>
+    {% block content %}{% endblock content %}
     <footer><p>EA Boston | Copyright 2017 Taymon Beal, Daniel Ziegler | Powered by Django</p></footer>
   </body>
 </html>

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8">
     <title>{% block fulltitle %}{% block title %}{% endblock title %} – EA Boston{% endblock fulltitle %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% block styling %}{% endblock styling %}
   </head>
-  <body>{% block content %}{% endblock content %}</body>
+  <body>
+    <main>{% block content %}{% endblock content %}</main>
+    <footer><p>EA Boston | Copyright 2017 Taymon Beal, Daniel Ziegler | Powered by Django</p></footer>
+  </body>
 </html>


### PR DESCRIPTION
I further modified the base HTML template to use `<details>` and `<summary>` to create collapsible events that, when unclicked, only showed the picture, title, and date, and put the locations in `<p>` tags as recommended.

I also created a responsive layout that, when wider than 30rem, uses a flexbox-based grid view (which has open events take up the full screen and move to the top of the page), and when 30rem or narrower, uses a tightly-packed column view.

Desktop preview:
![desktop screenshot](https://cloud.githubusercontent.com/assets/12678997/25688924/34add4e8-3051-11e7-8188-d7450ee6e4fd.png)

Mobile preview:
![mobile screenshot](https://cloud.githubusercontent.com/assets/12678997/25688945/61dfa400-3051-11e7-97b5-2521ec4f4c5f.png)
