### PR TITLE
Subscription form

### DIFF
--- a/project/config/urls.py
+++ b/project/config/urls.py
@@ -6,7 +6,7 @@ from django.conf.urls.static import static
 from django.contrib.admin import site as admin_site
 
 from ..events.views import EventDetailView, EventListView, PastEventListView
-from ..subscriptions.views import SubscriberUpdateView
+from ..subscriptions.views import NewSubscriptionView, SubscriberUpdateView
 
 
 uuid_pattern = (r'(?P<uuid>' +
@@ -19,6 +19,7 @@ urlpatterns = [
     url(r'^event/(?P<pk>\d+)/$', EventDetailView.as_view(), name='event_detail'),
     url(r'^past/$', PastEventListView.as_view(), name='event_past'),
     url(r'^admin/', admin_site.urls),
+    url(r'^subscribe/$', NewSubscriptionView.as_view(), name='subscribe'),
     url(r'^subscriptions/{uuid_pattern}/$'.format(uuid_pattern=uuid_pattern),
         SubscriberUpdateView.as_view(),
         name='subscriptions'),

--- a/project/config/urls.py
+++ b/project/config/urls.py
@@ -15,7 +15,7 @@ uuid_pattern = (r'(?P<uuid>' +
 
 
 urlpatterns = [
-    url(r'^$', EventListView.as_view(), name='event_list'),
+    url(r'^future/$', EventListView.as_view(), name='event_list'),
     url(r'^event/(?P<pk>\d+)/$', EventDetailView.as_view(), name='event_detail'),
     url(r'^past/$', PastEventListView.as_view(), name='event_past'),
     url(r'^admin/', admin_site.urls),

--- a/project/events/static/css/simplesheet.css
+++ b/project/events/static/css/simplesheet.css
@@ -11,7 +11,11 @@ header h1 {
 }
 header h1 a:hover, header h1 a:focus { text-shadow: 0 0 1ch #fff; }
 header h1 a { color: #fff; text-decoration: none; }
-.event { background-color: #fff; color: #000; }
+
+form #id_interests { list-style-type: none; padding: 0; }
+form h1 { margin: 0; }
+
+.event, form { background-color: #fff; color: #000; }
 summary { display: block; }
 .event h1 { margin: 0; }
 .event img { float: left; }
@@ -25,6 +29,9 @@ nav { text-align: center; }
 	main { display: flex; flex-flow: row wrap; justify-content: space-evenly; max-width: 90em; margin: 0 auto; }
 	body { line-height: 1.5; background-color: #ded; }
 	header h1 { font-size: 2em; padding: 0.5em 0; }
+
+	form { padding: 0.5em; margin: 0.5em; border: solid thin; min-width: 28rem; max-width: 40rem; }
+
 	.event { padding: 0.5em; margin: 0.5em; border: solid thin; flex: 1 0 20%;}
 	details.event:not([open]) { height: 8em; min-width: 20rem; max-width: 40rem; order: 2; }
 	details.event[open], article.event { min-width: calc(100% - 2em); min-height: 8em; order: 1; }
@@ -37,9 +44,13 @@ nav { text-align: center; }
 	body { font-size: 0.8em; line-height: 1.25; background-color: #fff; }
 	header h1 { padding: 0.1em 0; font-size: 2em; margin-bottom: 0.2em; }
 	nav { margin: 0.4em; }
+	p { margin: 0.5em 0; }
+
+	form { padding: 0.2em; }
+	form h1 { font-size: 1.25em; line-height: 1; }
+
 	.event { padding: 0.2em; border-bottom: solid thin; }
 	.event:first-child { border-top: solid thin; }
 	.event h1 { font-size: 1.25em; line-height: 1; }
 	.event img { height: 2.5em; margin-right: 0.1em; }
-	p { margin: 0.5em 0; }
 }

--- a/project/events/templates/events/event_detail.html
+++ b/project/events/templates/events/event_detail.html
@@ -2,9 +2,7 @@
 {% load staticfiles %}
 
 {% block fulltitle %}EA Boston Events{% endblock fulltitle %}
-{% block styling %}<link rel="stylesheet" href="{% static 'css/simplesheet.css' %}">{% endblock styling %}
 {% block content %}
-  <header><h1><a href="{% url 'event_list' %}">EA Boston Events</a></h1></header>
     <main>
           <article class="event">
               <img src="{{ event.picture.url }}" alt=""/>

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -12,7 +12,7 @@
             <summary>
               <img src="{{ event.picture.url }}" alt=""/>
               <h1>{{ event.name }}</h1>
-              <p class="date"><time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>{% if event.end_time %} -- <time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time }}</time>{% endif %}</p>
+              <p class="date"><time datetime="{{ event.start_time|date:'c' }}">{{ event.start_time }}</time>{% if event.end_time %}: <time datetime="{{ event.end_time|date:'c' }}">{{ event.end_time|timeuntil:event.start_time }}</time> long{% endif %}</p>
             </summary>
             <p>{{ event.location }}</p>
             <p>{{ event.description }}</p>

--- a/project/events/templates/events/event_list.html
+++ b/project/events/templates/events/event_list.html
@@ -4,7 +4,6 @@
 {% block fulltitle %}EA Boston Events{% endblock fulltitle %}
 {% block styling %}<link rel="stylesheet" href="{% static 'css/simplesheet.css' %}">{% endblock styling %}
 {% block content %}
-  <header><h1><a href="{% url 'event_list' %}">EA Boston Events</a></h1></header>
   {% if event_list %}
     <main>
       {% for event in event_list %}

--- a/project/subscriptions/forms.py
+++ b/project/subscriptions/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+from .models import Subscriber
+
+class NewSubscriberForm(forms.ModelForm):
+
+    class Meta:
+        model = Subscriber
+        fields = ('email', 'interests')

--- a/project/subscriptions/forms.py
+++ b/project/subscriptions/forms.py
@@ -7,9 +7,4 @@ class NewSubscriberForm(forms.ModelForm):
     class Meta:
         model = Subscriber
         fields = ('email', 'interests')
-
-    def save(self, *args, **kwargs):
-        if self.token is None:
-            self.token = Token()
-            self.token.save()
-        super(Subscriber, self).save(*args, **kwargs)
+        widgets = { 'interests': forms.CheckboxSelectMultiple }

--- a/project/subscriptions/forms.py
+++ b/project/subscriptions/forms.py
@@ -7,3 +7,9 @@ class NewSubscriberForm(forms.ModelForm):
     class Meta:
         model = Subscriber
         fields = ('email', 'interests')
+
+    def save(self, *args, **kwargs):
+        if self.token is None:
+            self.token = Token()
+            self.token.save()
+        super(Subscriber, self).save(*args, **kwargs)

--- a/project/subscriptions/forms.py
+++ b/project/subscriptions/forms.py
@@ -7,4 +7,4 @@ class NewSubscriberForm(forms.ModelForm):
     class Meta:
         model = Subscriber
         fields = ('email', 'interests')
-        widgets = { 'interests': forms.CheckboxSelectMultiple }
+        widgets = {'interests': forms.CheckboxSelectMultiple}

--- a/project/subscriptions/models.py
+++ b/project/subscriptions/models.py
@@ -17,6 +17,10 @@ from django.utils.encoding import force_text, python_2_unicode_compatible
 from ..events.models import Interest
 
 
+def create_token():
+    return Token.objects.create()
+
+
 @python_2_unicode_compatible
 class Token(Model):
 
@@ -43,7 +47,7 @@ class SubscriberManager(Manager):
 class Subscriber(Model):
 
     email = EmailField(unique=True)
-    token = OneToOneField(Token, on_delete=CASCADE)
+    token = OneToOneField(Token, on_delete=CASCADE, default=create_token)
     interests = ManyToManyField(Interest)
 
     objects = SubscriberManager()

--- a/project/subscriptions/templates/subscriptions/new_subscription.html
+++ b/project/subscriptions/templates/subscriptions/new_subscription.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block title %}Subscribe now!{% endblock title %}
+
+{% block content %}
+  <h1>Subscribe here</h1>
+  <form method="POST">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Update">
+  </form>
+{% endblock content %}

--- a/project/subscriptions/templates/subscriptions/new_subscription.html
+++ b/project/subscriptions/templates/subscriptions/new_subscription.html
@@ -3,10 +3,12 @@
 {% block title %}Subscribe now!{% endblock title %}
 
 {% block content %}
-  <h1>Subscribe here</h1>
+<main>
   <form method="POST">
+    <h1>Subscribe here</h1>
     {% csrf_token %}
     {{ form.as_p }}
     <input type="submit" value="Update">
   </form>
+</main>
 {% endblock content %}

--- a/project/subscriptions/templates/subscriptions/subscriber_form.html
+++ b/project/subscriptions/templates/subscriptions/subscriber_form.html
@@ -3,10 +3,12 @@
 {% block title %}Subscription Preferences{% endblock title %}
 
 {% block content %}
-  <h1>Subscription Preferences</h1>
+<main>
   <form method="POST">
+    <h1>Subscription Preferences</h1>
     {% csrf_token %}
     {{ form.as_p }}
     <input type="submit" value="Update">
   </form>
+</main>
 {% endblock content %}

--- a/project/subscriptions/views.py
+++ b/project/subscriptions/views.py
@@ -1,9 +1,14 @@
 from __future__ import unicode_literals
 
-from django.views.generic.edit import UpdateView
+from django.views.generic.edit import FormView, UpdateView
 
+from .forms import NewSubscriberForm
 from .viewmixins import SubscriberMixin
 
 
 class SubscriberUpdateView(SubscriberMixin, UpdateView):
     fields = ['interests']
+
+
+class NewSubscriptionView(FormView):
+    form_class = NewSubscriberForm

--- a/project/subscriptions/views.py
+++ b/project/subscriptions/views.py
@@ -12,3 +12,7 @@ class SubscriberUpdateView(SubscriberMixin, UpdateView):
 
 class NewSubscriptionView(FormView):
     form_class = NewSubscriberForm
+    template_name = 'subscriptions/new_subscription.html'
+
+    def form_valid(self, form):
+        print "You submitted a valid form, but we haven't set up any good success behavior yet. Sorry."

--- a/project/subscriptions/views.py
+++ b/project/subscriptions/views.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from django.contrib import messages
+from django.shortcuts import redirect
 from django.views.generic.edit import FormView, UpdateView
 
 from .forms import NewSubscriberForm
@@ -13,7 +15,9 @@ class SubscriberUpdateView(SubscriberMixin, UpdateView):
 class NewSubscriptionView(FormView):
     form_class = NewSubscriberForm
     template_name = 'subscriptions/new_subscription.html'
+    success_url = '/future/'
 
     def form_valid(self, form):
-        print "You submitted a valid form, but we haven't set up any good success behavior yet. Sorry."
         form.save()
+        messages.success(self.request, 'Thank you for subscribing.')
+        return redirect('event_list')

--- a/project/subscriptions/views.py
+++ b/project/subscriptions/views.py
@@ -16,3 +16,4 @@ class NewSubscriptionView(FormView):
 
     def form_valid(self, form):
         print "You submitted a valid form, but we haven't set up any good success behavior yet. Sorry."
+        form.save()

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -1,12 +1,16 @@
+{% load staticfiles %}
+
 <!DOCTYPE html>
 <html lang="en-US">
   <head>
     <meta charset="UTF-8">
     <title>{% block fulltitle %}{% block title %}{% endblock title %} – EA Boston{% endblock fulltitle %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{% static 'css/simplesheet.css' %}">
     {% block styling %}{% endblock styling %}
   </head>
   <body>
+    <header><h1><a href="{% url 'event_list' %}">EA Boston Events</a></h1></header>
     {% block content %}{% endblock content %}
   </body>
 </html>

--- a/project/templates/base.html
+++ b/project/templates/base.html
@@ -11,6 +11,15 @@
   </head>
   <body>
     <header><h1><a href="{% url 'event_list' %}">EA Boston Events</a></h1></header>
+    {% if messages %}
+    <section id="messages">
+      <ul>
+          {% for message in messages %}
+          <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+          {% endfor %}
+      </ul>
+    </section>
+    {% endif %}
     {% block content %}{% endblock content %}
   </body>
 </html>


### PR DESCRIPTION
Mostly closes #13 by creating a subscriber form. (Subscriber form is not on the homepage, because currently there is no homepage, just `/future/` and `/subscribe/`.) Further fixes #12 (which was already mostly fixed) by styling the subscriber settings page (although the subscriber settings page still uses the listbox and not checkboxes).